### PR TITLE
fix: state_type incorrect reference

### DIFF
--- a/tap_airbyte/tap.py
+++ b/tap_airbyte/tap.py
@@ -654,13 +654,14 @@ class TapAirbyte(Tap):
                     self._process_log_message(airbyte_message)
                 elif airbyte_message["type"] == AirbyteMessage.STATE:
                     state_message = airbyte_message["state"]
+                    state_type = state_message["type"]
                     if "data" in state_message:
                         unpacked_state = state_message["data"]
-                    elif "type" == "STREAM":
+                    elif state_type == "STREAM":
                         unpacked_state = state_message["stream"]
-                    elif "type" == "GLOBAL":
+                    elif state_type == "GLOBAL":
                         unpacked_state = state_message["global"]
-                    elif "type" == "LEGACY":
+                    elif state_type == "LEGACY":
                         unpacked_state = state_message["legacy"]
                     self.airbyte_state = unpacked_state
                     with STDOUT_LOCK:


### PR DESCRIPTION
Hi!

I've been trying to implement this tap for some time now, as we want to use the `CDC` implementation with the default `pgoutput` configuration. Using the postgres extractor definition here: https://hub.meltano.com/extractors/tap-postgres--airbyte/

But I've faced an issue where the `state` was not being picked up for some reason.
Eventually I figured it was missing the `metadata` definition to set the `replication-method`:
```
    metadata:
      '*':
        replication-method: LOG_BASED
```

But I've also noticed something else on the log:

```
2024-02-16T18:31:13.432770Z [info     ]     self.airbyte_state = unpacked_state cmd_type=elb consumer=False name=raw__REDACTED producer=True stdio=stderr string_id=raw__REDACTED
2024-02-16T18:31:13.433219Z [info     ] UnboundLocalError: local variable 'unpacked_state' referenced before assignment cmd_type=elb consumer=False name=raw__REDACTED producer=True stdio=stderr string_id=raw__REDACTED
2024-02-16T18:31:13.433660Z [info     ]                                cmd_type=elb consumer=False name=raw__REDACTED producer=True stdio=stderr string_id=raw__REDACTED
2024-02-16T18:31:13.434099Z [info     ] During handling of the above exception, another exception occurred: cmd_type=elb consumer=False name=raw__REDACTED producer=True stdio=stderr string_id=raw__REDACTED
2024-02-16T18:31:13.434545Z [info     ]                                cmd_type=elb consumer=False name=raw__REDACTED producer=True stdio=stderr string_id=raw__REDACTED
2024-02-16T18:31:13.434978Z [info     ] Traceback (most recent call last): cmd_type=elb consumer=False name=raw__REDACTED producer=True stdio=stderr string_id=raw__REDACTED
```

After some inspection I saw these statements on the code and after changing them to what this PR proposal, it started working as expected.

I'm wondering if this was not an issue for someone at some point.