### PR TITLE
fix: support incremental extraction with airbyte source defined cursor fields

### DIFF
--- a/tap_airbyte/tap.py
+++ b/tap_airbyte/tap.py
@@ -696,6 +696,12 @@ class TapAirbyte(Tap):
                 # this is [str, ...?] in the Airbyte catalog
                 if "cursor_field" in stream and isinstance(stream["cursor_field"][0], str):
                     airbyte_stream.replication_key = stream["cursor_field"][0]
+                elif "source_defined_cursor" in stream and isinstance(stream["source_defined_cursor"], bool) and stream["source_defined_cursor"]:
+                    # The stream has a source defined cursor. Try using that
+                    if "default_cursor_field" in stream and isinstance(stream["default_cursor_field"][0], str):
+                        airbyte_stream.replication_key = stream["default_cursor_field"][0]
+                    else:
+                        self.logger.warning(f"Stream {stream['name']} has a source defined cursor but no default_cursor_field.")
             except IndexError:
                 pass
             try:


### PR DESCRIPTION
See airbyte docs here 
 - https://docs.airbyte.com/understanding-airbyte/airbyte-protocol#configuredairbytestream
 - https://docs.airbyte.com/understanding-airbyte/airbyte-protocol#logic-for-resolving-the-cursor-field

The airbyte `discover` command does not return a `cursor_field` for incrementally enabled extractions. It returns `source_defined_cursor=true` and `default_cursor_field=[list_of_cursors]`