### PR TITLE
fix: Restore `--format` option

### DIFF
--- a/tap_airbyte/tap.py
+++ b/tap_airbyte/tap.py
@@ -212,6 +212,7 @@ class TapAirbyte(Tap):
     def cli(cls) -> t.Callable:
         @common_options.PLUGIN_VERSION
         @common_options.PLUGIN_ABOUT
+        @common_options.PLUGIN_ABOUT_FORMAT
         @common_options.PLUGIN_CONFIG
         @click.option(
             "--discover",
@@ -245,7 +246,7 @@ class TapAirbyte(Tap):
                 config: tuple[str, ...] = (),
                 state: t.Optional[str] = None,
                 catalog: t.Optional[str] = None,
-                cli_format: t.Optional[str] = None,
+                output_format: t.Optional[str] = None,
         ) -> None:
             if version:
                 cls.print_version()
@@ -281,13 +282,13 @@ class TapAirbyte(Tap):
                     spec = tap.run_spec()["connectionSpecification"]
                 except Exception:
                     cls.logger.info("Tap-Airbyte instantiation failed. Printing basic about info.")
-                    cls.print_about(output_format=cli_format)
+                    cls.print_about(output_format=abou_format)
                 else:
                     cls.logger.info(
                         "Tap-Airbyte instantiation succeeded. Printing spec-enriched about info."
                     )
                     cls.config_jsonschema["properties"]["airbyte_config"] = spec
-                    cls.print_about(output_format=cli_format)
+                    cls.print_about(output_format=about_format)
                     cls.print_spec_as_config(spec)
                 return
             # End modification

--- a/tap_airbyte/tap.py
+++ b/tap_airbyte/tap.py
@@ -246,7 +246,7 @@ class TapAirbyte(Tap):
                 config: tuple[str, ...] = (),
                 state: t.Optional[str] = None,
                 catalog: t.Optional[str] = None,
-                output_format: t.Optional[str] = None,
+                about_format: t.Optional[str] = None,
         ) -> None:
             if version:
                 cls.print_version()
@@ -282,7 +282,7 @@ class TapAirbyte(Tap):
                     spec = tap.run_spec()["connectionSpecification"]
                 except Exception:
                     cls.logger.info("Tap-Airbyte instantiation failed. Printing basic about info.")
-                    cls.print_about(output_format=abou_format)
+                    cls.print_about(output_format=about_format)
                 else:
                     cls.logger.info(
                         "Tap-Airbyte instantiation succeeded. Printing spec-enriched about info."


### PR DESCRIPTION
It was removed in https://github.com/MeltanoLabs/tap-airbyte-wrapper/commit/87da181a92e8a3bdda35ee26a96ec73974c07fe3#diff-ed817cab065e4c6d520120485629589b6e09dc6c0eec42adfc9d27d6f796d998, I'm curious if know why @pnadolny13.